### PR TITLE
Update `chai-react` to support React v0.13

### DIFF
--- a/chai-react.js
+++ b/chai-react.js
@@ -109,7 +109,7 @@
         }
       }
 
-      return !TestUtils.isTextComponent(comp) && name in comp.props;
+      return comp.props && name in comp.props;
     });
 
     if (undefined !== value) {
@@ -174,34 +174,6 @@
     flag(this, 'object', found);
   });
 
-  chai.Assertion.addMethod('textComponent', function (text) {
-    var actual, component = flag(this, 'object');
-
-    new chai.Assertion(component).is.a.component;
-
-    inspectify(component);
-
-    var textComponents = TestUtils.findAllInRenderedTree(component, function (comp) {
-      return TestUtils.isTextComponent(comp) || typeof comp.props.children === 'string';
-    });
-
-    var foundMatch = false;
-    for (var i = 0; i < textComponents.length; i++) {
-      if (textComponents[i].props === text || textComponents[i].props.children === text) {
-        flag(this, 'object', textComponents[i]);
-        foundMatch = true;
-        break;
-      }
-    }
-
-    this.assert(
-      foundMatch,
-      'expected component tree to have a text component with text #{exp}, but none was found.',
-      'expected component tree to not have a text component with text #{exp}, but one was found.',
-      text
-    );
-  });
-
   chai.Assertion.addProperty('component', function () {
     var component = flag(this, 'object');
 
@@ -220,15 +192,5 @@
       'expected #{this} to be a valid React element, but it is not',
       'expected #{this} to not be a valid React element, but it is'
     );
-  });
-
-  chai.Assertion.addMethod('triggerEvent', function (eventName, args) {
-    var component = flag(this, 'object');
-
-    new chai.Assertion(component).is.a.component;
-
-    new chai.Assertion(React.addons.TestUtils.Simulate[eventName]).is.a('function');
-
-    React.addons.TestUtils.Simulate[eventName](component.getDOMNode(), args);
   });
 }));

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "es5-shim": "^4.0.0",
     "mocha": "1",
     "mocha-phantomjs": "3",
-    "react": "^0.12.2"
+    "react": "^0.13.0"
   }
 }

--- a/test/chai-react-spec.js
+++ b/test/chai-react-spec.js
@@ -36,9 +36,9 @@ describe('chai-react', function() {
         { className: 'abc testing-class' },
         'separator text',
         React.createElement('span', { className: 'my-class other-class cool' }, 'my other span text'),
-        childComponent({}),
-        childComponent({ myVar: 5 }),
-        singleComponent({})
+        React.createElement(childComponent),
+        React.createElement(childComponent, { myVar: 5 }),
+        React.createElement(singleComponent)
       );
     }
   });
@@ -99,32 +99,32 @@ describe('chai-react', function() {
 
   describe('state', function () {
     it('works with initial state for top-level component', function() {
-      var component = utils.renderIntoDocument(childComponent());
+      var component = utils.renderIntoDocument(React.createElement(childComponent));
 
       expect(component).to.have.state('myState', 2);
     });
 
     it('allows chaining of other assertions', function() {
-      var component = utils.renderIntoDocument(childComponent());
+      var component = utils.renderIntoDocument(React.createElement(childComponent));
 
       expect(component).to.have.state('myState').gt(1);
     });
 
     it('works if expected value does not match, but is negated', function() {
-      var component = utils.renderIntoDocument(childComponent());
+      var component = utils.renderIntoDocument(React.createElement(childComponent));
 
       expect(component).to.not.have.state('myState', 3);
     });
 
     it('works if it does not have state', function() {
-      var component = utils.renderIntoDocument(childComponent());
+      var component = utils.renderIntoDocument(React.createElement(childComponent));
 
       expect(component).to.not.have.state('someOtherState');
     });
 
     it('fails if state does not match expected value', function() {
       expect(function () {
-        var component = utils.renderIntoDocument(childComponent());
+        var component = utils.renderIntoDocument(React.createElement(childComponent));
         expect(component).to.have.state('myState', 3);
       }).to.fail('expected component to have state \'myState\' with the value 2, but the value was 3');
     });
@@ -138,32 +138,32 @@ describe('chai-react', function() {
 
   describe('prop', function () {
     it('works with default prop for top-level component', function() {
-      var component = utils.renderIntoDocument(childComponent({ myVar: 5 }));
+      var component = utils.renderIntoDocument(React.createElement(childComponent, { myVar: 5 }));
 
       expect(component).to.have.prop('myVar', 5);
     });
 
     it('allows chaining of other assertions', function() {
-      var component = utils.renderIntoDocument(childComponent({ myVar: 5 }));
+      var component = utils.renderIntoDocument(React.createElement(childComponent, { myVar: 5 }));
 
       expect(component).to.have.prop('myVar').gt(4);
     });
 
     it('works if expected value does not match, but is negated', function() {
-      var component = utils.renderIntoDocument(childComponent({ myVar: 5 }));
+      var component = utils.renderIntoDocument(React.createElement(childComponent, { myVar: 5 }));
 
       expect(component).to.not.have.prop('myVar', 3);
     });
 
     it('works if it does not have prop', function() {
-      var component = utils.renderIntoDocument(childComponent({ myVar: 5 }));
+      var component = utils.renderIntoDocument(React.createElement(childComponent, { myVar: 5 }));
 
       expect(component).to.not.have.prop('someOtherProp');
     });
 
     it('fails if prop does not match expected value', function() {
       expect(function () {
-        var component = utils.renderIntoDocument(childComponent({ myVar: 5 }));
+        var component = utils.renderIntoDocument(React.createElement(childComponent, { myVar: 5 }));
         expect(component).to.have.prop('myVar', 3);
       }).to.fail('expected component to have prop \'myVar\' with the value 3, but the value was 5');
     });
@@ -177,13 +177,13 @@ describe('chai-react', function() {
 
   describe('componentsWithProp', function () {
     it('retrieves descendant components with prop', function () {
-      var component = utils.renderIntoDocument(testComponent());
+      var component = utils.renderIntoDocument(React.createElement(testComponent));
 
       expect(component).componentsWithProp('myVar').to.have.length(2);
     });
 
     it('filters descendant components with specific prop value', function () {
-      var component = utils.renderIntoDocument(testComponent());
+      var component = utils.renderIntoDocument(React.createElement(testComponent));
 
       expect(component).componentsWithProp('myVar', 5).to.have.length(1);
     });
@@ -196,7 +196,7 @@ describe('chai-react', function() {
 
     describe('state', function () {
       it('allows diving into state of a found component', function () {
-        var component = utils.renderIntoDocument(testComponent());
+        var component = utils.renderIntoDocument(React.createElement(testComponent));
 
         expect(component).componentsWithProp('myVar').first.to.have.state('myState', 2);
         expect(component).componentsWithProp('myVar').last.to.have.state('myState', 10);
@@ -205,7 +205,7 @@ describe('chai-react', function() {
 
     describe('prop', function () {
       it('allows diving into props of a found component', function () {
-        var component = utils.renderIntoDocument(testComponent());
+        var component = utils.renderIntoDocument(React.createElement(testComponent));
 
         expect(component).componentsWithProp('myVar').first.to.have.prop('myVar', 1);
         expect(component).componentsWithProp('myVar').last.to.have.prop('myVar', 5);
@@ -214,7 +214,7 @@ describe('chai-react', function() {
 
     describe('contains', function () {
       it('allows diving into props of a found component', function () {
-        var component = utils.renderIntoDocument(testComponent());
+        var component = utils.renderIntoDocument(React.createElement(testComponent));
 
         expect(component).componentsWithProp('className', 'my-class', 'contains').first.to.have.prop('className', 'my-class other-class cool');
       });
@@ -223,7 +223,7 @@ describe('chai-react', function() {
 
   describe('componentsWithTag', function () {
     it('retrieves descendant components of type', function () {
-      var component = utils.renderIntoDocument(testComponent());
+      var component = utils.renderIntoDocument(React.createElement(testComponent));
 
       expect(component).componentsWithTag('div').to.have.length(3);
     });
@@ -236,7 +236,7 @@ describe('chai-react', function() {
 
     describe('prop', function () {
       it('allows diving into props of a found component', function () {
-        var component = utils.renderIntoDocument(testComponent());
+        var component = utils.renderIntoDocument(React.createElement(testComponent));
 
         expect(component).componentsWithTag('div').atIndex(1).to.have.prop('children');
       });
@@ -245,7 +245,7 @@ describe('chai-react', function() {
 
   describe('componentWithTag', function () {
     it('retrieves descendant component of type', function () {
-      var component = utils.renderIntoDocument(testComponent());
+      var component = utils.renderIntoDocument(React.createElement(testComponent));
 
       expect(component).componentWithTag('h1').to.not.be.undefined;
     });
@@ -258,7 +258,7 @@ describe('chai-react', function() {
 
     describe('prop', function () {
       it('allows diving into props of a found component', function () {
-        var component = utils.renderIntoDocument(testComponent());
+        var component = utils.renderIntoDocument(React.createElement(testComponent));
 
         expect(component).componentWithTag('h1').to.have.prop('children');
       });
@@ -267,7 +267,7 @@ describe('chai-react', function() {
 
   describe('componentsOfType', function () {
     it('retrieves descendant components of type', function () {
-      var component = utils.renderIntoDocument(testComponent());
+      var component = utils.renderIntoDocument(React.createElement(testComponent));
 
       expect(component).componentsOfType(childComponent).to.have.length(2);
     });
@@ -280,7 +280,7 @@ describe('chai-react', function() {
 
     describe('state', function () {
       it('allows diving into state of a found component', function () {
-        var component = utils.renderIntoDocument(testComponent());
+        var component = utils.renderIntoDocument(React.createElement(testComponent));
 
         expect(component).componentsOfType(childComponent).first.to.have.state('myState', 2);
         expect(component).componentsOfType(childComponent).last.to.have.state('myState', 10);
@@ -289,7 +289,7 @@ describe('chai-react', function() {
 
     describe('prop', function () {
       it('allows diving into props of a found component', function () {
-        var component = utils.renderIntoDocument(testComponent());
+        var component = utils.renderIntoDocument(React.createElement(testComponent));
 
         expect(component).componentsOfType(childComponent).first.to.have.prop('myVar', 1);
         expect(component).componentsOfType(childComponent).last.to.have.prop('myVar', 5);
@@ -299,7 +299,7 @@ describe('chai-react', function() {
 
   describe('componentOfType', function () {
     it('retrieves a single descendant component of type', function () {
-      var component = utils.renderIntoDocument(testComponent());
+      var component = utils.renderIntoDocument(React.createElement(testComponent));
 
       expect(component).componentOfType(singleComponent).to.not.be.undefined;
     });
@@ -312,7 +312,7 @@ describe('chai-react', function() {
 
     describe('state', function () {
       it('allows diving into state of a found component', function () {
-        var component = utils.renderIntoDocument(testComponent());
+        var component = utils.renderIntoDocument(React.createElement(testComponent));
 
         expect(component).componentOfType(singleComponent).to.have.state('foo', 2);
       });
@@ -320,56 +320,16 @@ describe('chai-react', function() {
 
     describe('prop', function () {
       it('allows diving into props of a found component', function () {
-        var component = utils.renderIntoDocument(testComponent());
+        var component = utils.renderIntoDocument(React.createElement(testComponent));
 
         expect(component).componentOfType(singleComponent).to.have.prop('bar', 1);
       });
     });
   });
 
-  describe('textComponent', function () {
-    it('matches plain text components', function () {
-      var component = utils.renderIntoDocument(testComponent());
-
-      expect(component).to.have.textComponent('separator text');
-    });
-
-    it('matches component child text', function () {
-      var component = utils.renderIntoDocument(testComponent());
-
-      expect(component).to.have.textComponent('Child text');
-    });
-
-    it('negative assertions work', function () {
-      var component = utils.renderIntoDocument(testComponent());
-
-      expect(component).to.not.have.textComponent('abc');
-    });
-
-    it('negative assertions work when not text components exist', function () {
-      var component = utils.renderIntoDocument(React.createElement('div', {}));
-
-      expect(component).to.not.have.textComponent('abc');
-    });
-
-    it('fails when text is not found', function() {
-      var component = utils.renderIntoDocument(testComponent());
-
-      expect(function () {
-        expect(component).to.have.textComponent('abc');
-      }).to.fail('expected component tree to have a text component with text \'abc\', but none was found.');
-    });
-
-    it('fails with a non component', function() {
-      expect(function () {
-        expect('').to.have.textComponent('abc');
-      }).to.fail('expected \'\' to be a valid React component, but it is not');
-    });
-  });
-
   describe('component', function () {
     it('passes with a valid component', function () {
-      var component = utils.renderIntoDocument(testComponent());
+      var component = utils.renderIntoDocument(React.createElement(testComponent));
 
       expect(component).to.be.a.component;
     });
@@ -388,21 +348,6 @@ describe('chai-react', function() {
 
     it('fails with a non element', function() {
       expect('').to.not.be.a.element;
-    });
-  });
-
-  describe('triggerEvent', function () {
-    it('triggers a component event', function () {
-      var component = utils.renderIntoDocument(testComponent());
-
-      expect(component).to.have.a.textComponent('Hello, this is my state: 2');
-      expect(component).to.not.have.a.textComponent('Hello, this is my state: 3');
-
-      expect(component).to.have.a.textComponent('Child text')
-        .and.triggerEvent('click');
-
-      expect(component).to.not.have.a.textComponent('Hello, this is my state: 2');
-      expect(component).to.have.a.textComponent('Hello, this is my state: 3');
     });
   });
 });


### PR DESCRIPTION
* Removed all text component functionality. Instead, you can use
`rquery`'s `text()` method.
* Removed the `triggerEvent` method. Instead, you can use `rquery`'s
event trigger methods.