### PR TITLE
Make compatible with React 16

### DIFF
--- a/chai-react.js
+++ b/chai-react.js
@@ -34,6 +34,8 @@
       } else {
         return component.getAttribute(prop);
       }
+    } else if (component.nodeType === Node.TEXT_NODE) {
+      // Skip text nodes as they don't have any props
     } else {
       return component.props[prop];
     }

--- a/chai-react.js
+++ b/chai-react.js
@@ -3,11 +3,11 @@
   if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
     // NodeJS
     module.exports = function (chai, utils) {
-      return chaiReact(chai, utils, require('react'), require('react-addons-test-utils'));
+      return chaiReact(chai, utils, require('react'), require('react-dom/test-utils'));
     };
   } else if (typeof define === "function" && define.amd) {
     // AMD
-    define(['react', 'react-addons-test-utils'], function (React, TestUtils) {
+    define(['react', 'react-dom/test-utils'], function (React, TestUtils) {
       return function (chai, utils) {
         return chaiReact(chai, utils, React, TestUtils);
       };
@@ -15,7 +15,7 @@
   } else {
     // Other environment (usually <script> tag): plug in to global chai instance directly.
     chai.use(function (chai, utils) {
-      return chaiReact(chai, utils, React, React.addons.TestUtils);
+      return chaiReact(chai, utils, React, ReactTestUtils);
     });
   }
 }(function (chai, utils, React, TestUtils) {

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   "devDependencies": {
     "chai": "1",
     "chai-array": "0.0.1",
+    "create-react-class": "^15.6.3",
     "envify": "^1.2.1",
     "es5-shim": "^4.0.0",
     "mocha": "1",
     "mocha-phantomjs": "3",
-    "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "devDependencies": {
     "chai": "1",
     "chai-array": "0.0.1",
+    "core-js": "^2.6.5",
     "create-react-class": "^15.6.3",
     "envify": "^1.2.1",
-    "es5-shim": "^4.0.0",
     "mocha": "1",
     "mocha-phantomjs": "3",
     "react": "^16.0.0",

--- a/test/chai-react-spec.js
+++ b/test/chai-react-spec.js
@@ -27,9 +27,9 @@ describe('chai-react', function() {
     });
   });
 
-  var utils = React.addons.TestUtils;
+  var utils = ReactTestUtils;
 
-  var testComponent = React.createClass({
+  var testComponent = createReactClass({
     render: function () {
       return React.createElement(
         'div',
@@ -43,7 +43,7 @@ describe('chai-react', function() {
     }
   });
 
-  var childComponent = React.createClass({
+  var childComponent = createReactClass({
     getDefaultProps: function () {
       return {
         myVar: 1,
@@ -75,7 +75,7 @@ describe('chai-react', function() {
     }
   })
 
-  var singleComponent = React.createClass({
+  var singleComponent = createReactClass({
     getDefaultProps: function () {
       return {
         bar: 1

--- a/test/index.html
+++ b/test/index.html
@@ -4,7 +4,10 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
     <script src="../node_modules/es5-shim/es5-shim.js"></script>
-    <script src="../node_modules/react/dist/react-with-addons.js"></script>
+    <script src="../node_modules/react/umd/react.development.js"></script>
+    <script src="../node_modules/react-dom/umd/react-dom.development.js"></script>
+    <script src="../node_modules/react-dom/umd/react-dom-test-utils.development.js"></script>
+    <script src="../node_modules/create-react-class/create-react-class.js"></script>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/chai/chai.js"></script>
     <script src="../node_modules/chai-array/chai-array.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -3,7 +3,7 @@
     <title>Mocha</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
-    <script src="../node_modules/es5-shim/es5-shim.js"></script>
+    <script src="../node_modules/core-js/client/shim.min.js"></script>
     <script src="../node_modules/react/umd/react.development.js"></script>
     <script src="../node_modules/react-dom/umd/react-dom.development.js"></script>
     <script src="../node_modules/react-dom/umd/react-dom-test-utils.development.js"></script>


### PR DESCRIPTION
This PR makes `chai-react` compatible with React 16. The test file passes when ran in browser.

<details>
<summary>Old description hidden below</summary>

This might allow React 16 to still work with this package. The `react-addons-test-utils` package has been deprecated and one should use `react-dom/test-utils` instead: https://reactjs.org/blog/2017/09/26/react-v16.0.html#packaging

This change allows us to remove `react-addons-test-utils` from our repository altogether while legacy tests still using `chai-react` pass now.

Let me know if I can help you with getting this to some release :relaxed:

EDIT: Unfortunately it seems this isn't enough to make `chai-react` compatible with React 16. Oh well. I'll see if there's a way to make this compatible with React 16, or if it would be easier to migrate tests away from `chai-react` altogether

</details>